### PR TITLE
added sync issue states workflow

### DIFF
--- a/.github/workflows/sync-issue-states.yml
+++ b/.github/workflows/sync-issue-states.yml
@@ -1,0 +1,24 @@
+name: Project Issue State Sync
+
+on:
+  schedule:
+    # At minute 0 every 2 hours
+    - cron: 0 0-23/2 * * *
+
+  workflow_dispatch:
+    # Manual trigger
+
+jobs:
+  issue-state-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Sync issue states
+        uses: dasmerlon/project-issue-state-sync@v2
+        with:
+          github_token: ${{ secrets.PROJECT_ISSUE_SYNC_TOKEN }}
+          owner: NathanGrenier
+          project_number: 2
+          verbosity: debug
+          closed_statuses: ✅ Done
+          open_statuses: ❌ Blocked,🕒 Todo,🔧 In Progress


### PR DESCRIPTION
### 🛠 Proposed Changes:

Added wokflow to sync issue states in the repo's project based on what column they're in.

### 📝 Details:
The workflow can be run manually. It also runs every 2 hours.
