### PR TITLE
docs: added link meeting minutes wiki in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ The full list of technologies used with explanations for their purpose in the
 project can be found on
 [this wiki page](https://github.com/NathanGrenier/SOEN-341/wiki/Technologies-Used-in-Project).
 
+## Meeting Minutes
+
+A detailed record of the meetings conducted by the team can be viewed through
+the following
+[wiki page](https://github.com/NathanGrenier/SOEN-341/wiki/Meeting-Minutes).
+
 ## Development
 
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)


### PR DESCRIPTION
### 🛠 Proposed Changes:

This PR adds a Meeting Minutes section to the README.md file.

### 📝 Details:

- Updated README.md file, which now contains a link to the GitHub wiki page containing notes of the meetings conducted by the team so far.
