### PR TITLE
fix: running npx prisma db seed with no environment paramater now see…

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -514,18 +514,20 @@ async function main() {
     values: { environment },
   } = parseArgs({ options: { environment: { type: "string" } } });
 
+  if (environment) {
+    console.log(`Seeding database for environment: ${environment}`);
+  } else {
+    console.log("No environment specified, seeding test data.");
+  }
+
   switch (environment) {
     case "production":
     case "develop":
       await seedMain();
       break;
     case "preview":
-      await testSeed();
-      break;
     default:
-      console.log(
-        `Invalid environment "${environment}". Please provide a valid environment.`,
-      );
+      await testSeed();
       break;
   }
 }


### PR DESCRIPTION
…ds the test data instead of crashing

### 🛠 Proposed Changes:

The `npx primsa db seed` command now works with no environment command line argument supplied. 

### 📝 Details:

- Running the command with no args will seed the database with the test data (located in the `testSeed()` function)
